### PR TITLE
sendData with array, delay, repeat, callback

### DIFF
--- a/helpers/sendData.js
+++ b/helpers/sendData.js
@@ -2,40 +2,72 @@ const assert = require('assert')
 
 const discoveredDevices = require('./devices.js');
 
-module.exports = (host, payload, log) => {
-  assert(payload && typeof payload === 'string', 'HEX value is missing')
-
-  // Get the Broadlink device, use the first one of no host is provided
-  let device;
-
-  if (host) {
-    device = discoveredDevices[host];
-  } else {
-    const hosts = Object.keys(discoveredDevices);
-    if (hosts.length === 0) return log(`Send data (no devices found)`);
-
-    device = discoveredDevices[hosts[0]];
+function sendData(host, payload, log, callback) {
+  if (payload instanceof Array) {
+    if (payload.length > 0) {
+      sendData(host,payload[0],log,function(){
+        sendData(host,payload.slice(1),log,callback)
+      })
+    }    
+  } 
+  if (!(payload instanceof Array) && payload instanceof Object) {
+    if (payload.repeat) {
+      const repeatedPayload = []
+      const payloadClone = JSON.parse(JSON.stringify(payload))
+      delete payloadClone.repeat
+      for (let i =0; i< payload.repeat; i++) {
+        repeatedPayload.push(payloadClone);
+      }
+      sendData(host,repeatedPayload,log,callback)
+    } else {
+      if (payload.waitAfter) {
+        sendData(host,payload.hex,log,null)
+        setTimeout(function(){
+          callback()
+        },payload.waitAfter)        
+      }    
+    }
+    
   }
+  if (typeof payload === 'string') {
+    // Get the Broadlink device, use the first one of no host is provided
+    let device;
 
-  if (!device) return log(`Send data (no device found at ${host})`);
+    if (host) {
+      device = discoveredDevices[host];
+    } else {
+      const hosts = Object.keys(discoveredDevices);
+      if (hosts.length === 0) return log(`Send data (no devices found)`);
 
-  const macAddressParts = device.mac.toString('hex').match(/[\s\S]{1,2}/g) || []
-  const macAddress = macAddressParts.join(':')
+      device = discoveredDevices[hosts[0]];
+    }
 
-  if (!device.sendData) {
-    log(`[ERROR] The device at ${device.host.address} (${macAddress}) doesn't support the sending of IR or RF codes.`);
+    if (!device) return log(`Send data (no device found at ${host})`);
 
-    return
+    const macAddressParts = device.mac.toString('hex').match(/[\s\S]{1,2}/g) || []
+    const macAddress = macAddressParts.join(':')
+
+    if (!device.sendData) {
+      log(`[ERROR] The device at ${device.host.address} (${macAddress}) doesn't support the sending of IR or RF codes.`);
+
+      return
+    }
+
+    if (payload.includes('5aa5aa555')) {
+      log('[ERROR] This type of hex code (5aa5aa555...) is no longer valid. Use the included "Learn IR" accessory to find new (decrypted) codes.');
+
+      return
+    }
+    
+    const packet = new Buffer(payload, 'hex');
+    device.sendData(packet);
+    
+
+    log(`Payload message sent to Broadlink RM device (${device.host.address}; ${macAddress})`);
+    if (typeof callback == 'function') {
+      callback()
+    }
   }
-
-  if (payload.includes('5aa5aa555')) {
-    log('[ERROR] This type of hex code (5aa5aa555...) is no longer valid. Use the included "Learn IR" accessory to find new (decrypted) codes.');
-
-    return
-  }
-
-  const packet = new Buffer(payload, 'hex');
-  device.sendData(packet);
-
-  log(`Payload message sent to Broadlink RM device (${device.host.address}; ${macAddress})`);
 }
+
+module.exports = sendData


### PR DESCRIPTION
Instead of bare string like now, I've tried to upgrade the `sendData` to support following schema in payload. 

Repeat and array and waitAfter 
```json
[
 {"hex": "260058000001269412121237131114121236133615101413113613111536123613121411123712381236131115111410141113131311143513121435133712361336153513361213120005260001284912000c4f0001284715000d05", "waitAfter": 1000, "repeat": 2},
"260058000001269412121237131114121236133615101413113613111536123613121411123712381236131115111410141113131311143513121435133712361336153513361213120005260001284912000c4f0001284715000d05"
]
```

Bare string still supported
```json
"260058000001269412121237131114121236133615101413113613111536123613121411123712381236131115111410141113131311143513121435133712361336153513361213120005260001284912000c4f0001284715000d05"
```

This could replace the switch-multi and switch-repeat (albeit the auto off after sending success)
Also, the sendData will now have callback, which will obviously help Homeapp UX

I'm sorry for undocumented code, but this works great with my projector (on: power toggle + switch input, off:  2x power toggle)