### PR TITLE
Fix for accessory state switch error

### DIFF
--- a/accessories/accessory.js
+++ b/accessories/accessory.js
@@ -95,7 +95,7 @@ class BroadlinkRMAccessory {
         return;
       }
 
-      if (!ignorePreviousValue && this.state[propertyName] === value && !this.isReloadingState) {
+      if (!ignorePreviousValue && this.state[propertyName] == value && !this.isReloadingState) {
         log(`${name} set${capitalizedPropertyName}: already ${value}`);
 
         callback(null, value);


### PR DESCRIPTION
The accessory state would be error if control with Home App and Siri together. As the log bellow, control by Home App, state will be 1 or 0. But by Siri, state will be true or false. 

[5/1/2017, 12:09:06 PM] [Broadlink RM] TV On/Off setSwitchState: true
[5/1/2017, 12:09:06 PM] [Broadlink RM] TV On/Off setSwitchState: already true
[5/1/2017, 12:09:18 PM] [Broadlink RM] TV On/Off setSwitchState: 0
[5/1/2017, 12:09:18 PM] [Broadlink RM] TV On/Off sendHex (192.168.199.183; ****)
[5/1/2017, 12:09:20 PM] [HomeAssistant] Received event: ping
[5/1/2017, 12:09:27 PM] [Broadlink RM] TV On/Off setSwitchState: false
[5/1/2017, 12:09:27 PM] [Broadlink RM] TV On/Off sendHex (192.168.199.183; ****)
[5/1/2017, 12:10:01 PM] [Broadlink RM] TV On/Off setSwitchState: false
[5/1/2017, 12:10:01 PM] [Broadlink RM] TV On/Off setSwitchState: already false
