### PR TITLE
Multi-code fan accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ offSendCount (optional) | If you set separate "on" and "off" codes you can use t
 interval (optional) | The amount of time between each send of a hex code in seconds. | 0.3 | 1
 disableAutomaticOff (optional) | Prevent the switch from turning off automatically when complete. | true | false
 
-
 ### fan
 
 Turn the fan on and the "on" hex code is sent, turn it off and the "off" hex code is sent.
@@ -116,14 +115,23 @@ key | description | example | default
 --- | ----------- | ------- | -------
 data (required) | Hex data stored as a key-value JSON object. | See below. | -
 
+### fan-multi
+
+Much like the `fan` accessory, but with the ability to send multiple hex codes for on and off commands.
+
+key | description | example | default
+--- | ----------- | ------- | -------
+data (required) | Hex data stored as an array of strings. You can also set separate "on" and "off" arrays of codes similar to the `switch`/`switch-multi` accessory. | [ "26005800000..." ] | -
+
 #### "data" key-value object
 
 key | description
 --- | -----------
-on | A hex code string to be sent when the switch is changed to the on position.
-off | A hex code string to be sent when the switch is changed to the off position.
+on | An array of hex code strings to be sent when the fan is turned on.
+off | An array of hex code strings to be sent when the fan is turned off.
 swingToggle | A hex code string used to toggle the swing mode on/off.
 fanSpeedX | A hex code string where X is any fan speed you wish to support e.g. "fanSpeed100".
+
 
 
 ### light

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ disableLogs (optional) | Disables the log output for this accessory. | true | fa
 - [switch-multi](#switch-multi)
 - [switch-repeat](#switch-repeat)
 - [fan](#fan)
+- [fan-multi](#fan-multi)
 - [light](#light)
 - [garage-door-opener](#garage-door-opener)
 - [window-covering](#window-covering)

--- a/accessories/fanMulti.js
+++ b/accessories/fanMulti.js
@@ -1,0 +1,139 @@
+const sendData = require('../helpers/sendData');
+const delayForDuration = require('../helpers/delayForDuration')
+const BroadlinkRMAccessory = require('./accessory');
+
+class FanMultiAccessory extends BroadlinkRMAccessory {
+
+  constructor (log, config = {}) {
+    super(log, config)
+
+    const { data } = this
+
+	// NB:  data is actually a dictionary/object ¯\_(ツ)_/¯
+	// keeping message for consistency
+    if (!Array.isArray(data)) return log('The "fan-multi" type requires the config value for "data" to be an array of hex codes.')
+  }
+
+  async setSwitchState (hexData) {
+    if (hexData) this.performSend(hexData);
+  }
+  
+  // lifted from fan.js
+  async setFanSpeed (hexData) {
+    const { data, host, log, state , name} = this;
+
+    const allHexKeys = Object.keys(data);
+
+    // Create an array of speeds specified in the data config
+    const foundSpeeds = [];
+
+    allHexKeys.forEach((key) => {
+      const parts = key.split('fanSpeed');
+
+      if (parts.length !== 2) return;
+
+      foundSpeeds.push(parts[1])
+    })
+
+    // Find speed closest to the one requested
+    const closest = foundSpeeds.reduce((prev, curr) => Math.abs(curr - state.fanSpeed) < Math.abs(prev - state.fanSpeed) ? curr : prev);
+    log(`${name} setFanSpeed: (closest: ${closest})`);
+
+    // Get the closest speed's hex data
+    hexData = data[`fanSpeed${closest}`];
+
+	for (let index = 0; index < data.length; index++) {
+      const hexData = data[index]
+
+      sendData({ host, hexData, log, name });
+
+      if (index < data.length - 1) await delayForDuration(interval);
+    }
+    
+  }
+
+  async performSend (data) {
+    const { config, host, log, name, state } = this;
+    let { disableAutomaticOff, interval } = config;
+
+    // Itterate through each hex config in the array
+    for (let index = 0; index < data.length; index++) {
+      const hexData = data[index]
+
+      sendData({ host, hexData, log, name });
+
+      if (index < data.length - 1) await delayForDuration(interval);
+    }
+
+    if (state.switchState && !disableAutomaticOff) {
+      await delayForDuration(0.1);
+
+      this.switchService.setCharacteristic(Characteristic.On, 0);
+    }
+  }
+
+  getServices () {
+    const services = super.getServices();
+    const { data, name } = this;
+    const { on, off, swingToggle } = data;
+	
+	 // Until FanV2 service is supported completely in Home app, we have to add legacy
+    let service = new Service.Fan(name);
+
+    this.addNameService(service);
+    this.createToggleCharacteristic({
+      service,
+      characteristicType: Characteristic.On,
+      propertyName: 'switchState',
+      onData: Array.isArray(data) ? data : data.on,
+      offData: Array.isArray(data) ? undefined : data.off,
+      setValuePromise: this.setSwitchState.bind(this)
+    });
+
+    this.createToggleCharacteristic({
+      service,
+      characteristicType: Characteristic.RotationSpeed,
+      propertyName: 'fanSpeed',
+      setValuePromise: this.setFanSpeed.bind(this)
+    });
+
+    services.push(service);
+
+
+	// Fanv2 service
+    service = new Service.Fanv2(name);
+    this.addNameService(service);
+
+    this.createToggleCharacteristic({
+      service,
+      characteristicType: Characteristic.Active,
+      propertyName: 'switchState',
+      onData: Array.isArray(data) ? data : data.on,
+      offData: Array.isArray(data) ? undefined : data.off,
+      setValuePromise: this.setSwitchState.bind(this)
+    });
+    
+    this.createToggleCharacteristic({
+      service,
+      characteristicType: Characteristic.SwingMode,
+      propertyName: 'swingMode',
+      onData: swingToggle,
+      offData: swingToggle
+    });
+	
+    this.createToggleCharacteristic({
+      service,
+      characteristicType: Characteristic.RotationSpeed,
+      propertyName: 'fanSpeed',
+      setValuePromise: this.setFanSpeed.bind(this)
+    });
+
+    services.push(service);
+
+    this.switchService = service;
+
+    return services;
+  }
+}
+
+module.exports = FanMultiAccessory;

--- a/accessories/index.js
+++ b/accessories/index.js
@@ -7,6 +7,7 @@ const SwitchMultiRepeat = require('./switchMultiRepeat');
 const SwitchRepeat = require('./switchRepeat');
 const UpDown = require('./upDown');
 const Fan = require('./fan');
+const FanMulti = require('./fanMulti');
 const GarageDoorOpener = require('./garageDoorOpener');
 const Light = require('./light');
 const WindowCovering = require('./windowCovering');
@@ -21,6 +22,7 @@ module.exports = {
   SwitchRepeat,
   UpDown,
   Fan,
+  FanMulti,
   GarageDoorOpener,
   Light,
   WindowCovering

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class BroadlinkRMPlatform extends HomebridgePlatform {
         'switch-multi-repeat': Accessory.SwitchMultiRepeat,
         'switch-repeat': Accessory.SwitchRepeat,
         'fan': Accessory.Fan,
+        'fan-multi': Accessory.FanMulti,
         'light': Accessory.Light,
         'window-covering': Accessory.WindowCovering,
       }


### PR DESCRIPTION
I have several fans that unfortunately have stateful commands.  In order to get the desired on/off effect (i.e. turn them on and off at lower than full power), I have to send multiple hex codes.

Ideally, I'd track the state of these fans on the Homebridge side and send the right commands as appropriate to set the actual fan speed, but this is a start that at least would allow those state transitions to use multiple hex codes.  I intend to follow this PR with that work.

It seems like there is an opportunity to make this inherit more from the `multi-switch` accessory, but this is my first attempt at writing anything for Node.

There's also a note in there about the logging about the type of `data` - it looks to me like in both this accessory and the `multi-switch` accessory, `data` is expected to be an Object / dictionary with array values rather than an array, so this error message shows when using the example `multi-switch` configuration (which works).