### PR TITLE
aircon - send on code before setting temperature if the aircon is off

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -265,7 +265,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
 
     if (state.currentHeatingCoolingState === Characteristic.TargetHeatingCoolingState.OFF && sendOnWhenOff) {
       log(`${name} sendTemperature (turning on before setting temperature)`);
-
+      sendData({host, hexData: data.on, log, name, debug});
       
       this.targetHeatingCoolingState = 'auto'
       this.setTargetHeatingCoolingState()


### PR DESCRIPTION
Currently no "on" code is being sent even when "sendOnWhenOff" is set to true. 