### PR TITLE
Added import accessory

### DIFF
--- a/accessories/importCode.js
+++ b/accessories/importCode.js
@@ -1,0 +1,152 @@
+const fs = require('fs');
+const http = require('http');
+const unzip = require('unzip');
+
+const ServiceManager = require('../helpers/serviceManager');
+const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
+
+const BroadlinkRMAccessory = require('./accessory');
+
+class ImportAccessory extends BroadlinkRMAccessory {
+
+    constructor(log, config = {}, serviceManagerType) {
+        // Set a default name for the accessory
+        if (!config.name) config.name = 'Import Code';
+        config.persistState = false;
+
+
+        super(log, config, serviceManagerType);
+
+        this.tmpPath = "/tmp/BLImport";
+    }
+
+    toggleImport(props, on, callback) {
+        if (on) {
+            let bonjour = require('bonjour')();
+
+            bonjour.find({type: 'http'}, this.serviceDiscovered.bind(this));
+
+            console.log("Import listener started, go to the app and click on 'Share to other phones in WLAN'");
+        } else {
+            callback();
+        }
+    }
+
+    serviceDiscovered(service) {
+        if (service.port === 48815) {
+            this
+                .initiateDownload("http://" + service.host + ":" + service.port)
+                .then(this.extractArchive.bind(this))
+                .then(this.extractCodes.bind(this))
+                .then(this.printCodes.bind(this))
+                .catch((error) => {
+                    console.log("Import failed: ", error);
+                });
+        }
+    }
+
+    initiateDownload(server) {
+        console.log("Download from:", server);
+
+        return new Promise((resolve, reject) => {
+            let path = this.tmpPath + "/shared.zip";
+
+            if (!fs.existsSync(this.tmpPath)) {
+                fs.mkdirSync(this.tmpPath);
+            }
+
+            let file = fs.createWriteStream(path);
+
+            http.get(server, function (response) {
+                response.pipe(file);
+
+                file.on('finish', function () {
+                    file.close();  // close() is async, call cb after close completes.
+
+                    resolve(path);
+                });
+            }).on('error', function (err) { // Handle errors
+                fs.unlink(path, () => {}); // Delete the file async. (But we don't check the result)
+
+                reject(err.message);
+            });
+        })
+    }
+
+    extractArchive(path) {
+        console.log("Extract archive:", path);
+        let destinationPath = this.tmpPath;
+
+        return new Promise((resolve, reject) => {
+            fs.createReadStream(path)
+                .pipe(unzip.Extract({path: destinationPath}))
+                .on('close', function () {
+                    resolve(destinationPath);
+                })
+                .on('error', function () {
+                    reject('Extracting archive failed');
+                });
+
+        })
+    }
+
+    extractCodes(path) {
+        console.log("Extract codes from:", path);
+
+        return new Promise((resolve, reject) => {
+            let rawButtons = fs.readFileSync(path + '/SharedData/jsonButton');
+            let buttons = JSON.parse(rawButtons);
+
+            let rawCodes = fs.readFileSync(path + '/SharedData/jsonIrCode');
+            let codes = JSON.parse(rawCodes);
+
+            let hexCodes = [];
+            codes.forEach((code) => {
+                let button = buttons.filter((button) => { return button.id === code.buttonId; }).pop();
+
+                if (button !== undefined) {
+                    hexCodes.push({
+                        name: button.name,
+                        hex: this.convertToHex(code.code)
+                    });
+                }
+            });
+
+            resolve(hexCodes);
+        })
+    }
+
+    printCodes(codes) {
+        console.log("Codes:", codes);
+    }
+
+    convertToHex(code) {
+        let hex = "";
+
+        code.forEach((decimal) => {
+            let hexValue = Number(decimal>>>0).toString(16);
+
+            hex += hexValue.substring(hexValue.length-2);
+        });
+
+        return hex;
+    }
+
+    setupServiceManager() {
+        const {data, name, config, serviceManagerType} = this;
+        const {on, off} = data || {};
+
+        this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, Service.Switch, this.log);
+
+        this.serviceManager.addToggleCharacteristic({
+            name: 'switchState',
+            type: Characteristic.On,
+            getMethod: this.getCharacteristicValue,
+            setMethod: this.toggleImport.bind(this),
+            bind: this,
+            props: {}
+        })
+    }
+}
+
+module.exports = ImportAccessory;

--- a/accessories/index.js
+++ b/accessories/index.js
@@ -2,6 +2,7 @@ const AirCon = require('./aircon');
 const AirPurifier = require('./air-purifier');
 const HumidifierDehumidifier = require('./humidifier-dehumidifier');
 const LearnCode = require('./learnCode');
+const ImportAccessory = require('./importCode');
 const Outlet = require('./outlet');
 const Switch = require('./switch');
 const SwitchMulti = require('./switchMulti');
@@ -19,6 +20,7 @@ module.exports = {
   AirPurifier,
   HumidifierDehumidifier,
   LearnCode,
+  ImportAccessory,
   Switch,
   SwitchMulti,
   SwitchMultiRepeat,

--- a/accessories/learnCode.js
+++ b/accessories/learnCode.js
@@ -7,7 +7,7 @@ const BroadlinkRMAccessory = require('./accessory');
 
 class LearnIRAccessory extends BroadlinkRMAccessory {
 
-  constructor (log, config = {}, serviceManagerType) {    
+  constructor (log, config = {}, serviceManagerType) {
 
     // Set a default name for the accessory
     if (!config.name) config.name = 'Learn Code';
@@ -59,9 +59,8 @@ class LearnIRAccessory extends BroadlinkRMAccessory {
       setMethod: this.toggleLearning.bind(this),
       bind: this,
       props: {
-      
-      },
-      bind: this
+
+      }
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-rm",
-  "version": "3.6.11",
+  "version": "3.6.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platform.js
+++ b/platform.js
@@ -13,6 +13,7 @@ const classTypes = {
   'humidifier-dehumidifier': Accessory.HumidifierDehumidifier,
   'learn-ir': Accessory.LearnCode,
   'learn-code': Accessory.LearnCode,
+  'import-code': Accessory.ImportAccessory,
   'switch': Accessory.Switch,
   'garage-door-opener': Accessory.GarageDoorOpener,
   'lock': Accessory.Lock,
@@ -84,16 +85,16 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
 
       return;
     }
-    
+
     discoverDevices(false, log, debug);
 
     log(`\x1b[35m[INFO]\x1b[0m Automatic Broadlink RM device discovery has been disabled as the "hosts" option has been set.`)
 
     assert.isArray(hosts, `\x1b[31m[CONFIG ERROR] \x1b[33mhosts\x1b[0m should be an array of objects.`)
-      
+
     hosts.forEach((host) => {
       assert.isObject(host, `\x1b[31m[CONFIG ERROR] \x1b[0m Each item in the \x1b[33mhosts\x1b[0m array should be an object.`)
-      
+
       const { address, isRFSupported, mac } = host;
       assert(address, `\x1b[31m[CONFIG ERROR] \x1b[0m Each object in the \x1b[33mhosts\x1b[0m option should contain a value for \x1b[33maddress\x1b[0m (e.g. "192.168.1.23").`)
       assert(mac, `\x1b[31m[CONFIG ERROR] \x1b[0m Each object in the \x1b[33mhosts\x1b[0m option should contain a unique value for \x1b[33mmac\x1b[0m (e.g. "34:ea:34:e7:d7:28").`)


### PR DESCRIPTION
More work needed

Added import accessory to get the codes using the e-control app share feature

TODO:
 - cleanup files after the import
 - better codes output
 - the actual parse of the files requires more work to support more use cases, this was done as a proof of concept to get the single switch I currently have
 - fix the state of the switch resetting in home app when refreshing (help needed, I get a "Import codes getSwitchState: undefined" in the log, but I could not find any example of getSwitchState used anywhere)