### PR TITLE
Fix 'log is not a function'

### DIFF
--- a/helpers/learnData.js
+++ b/helpers/learnData.js
@@ -15,7 +15,7 @@ const stop = (log) => {
 }
 
 const start = (host, callback, turnOffCallback, log, disableTimeout) => {
-  stop()
+  stop(log);
 
   log(`\x1b[35m[INFO]\x1b[0m Learn Code initializing (${host})`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-rm",
-  "version": "3.6.11",
+  "version": "3.6.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes a crash that sometimes occurs when entering learn mode right after startup.

E,g,:

```
[1/14/2020, 11:20:57 PM] TypeError: log is not a function
    at stop (/Users/qwtel/.npm-packages/lib/node_modules/homebridge-broadlink-rm/helpers/learnData.js:14:3)
    at Object.start (/Users/qwtel/.npm-packages/lib/node_modules/homebridge-broadlink-rm/helpers/learnData.js:18:3)
    at LearnIRAccessory.toggleLearning (/Users/qwtel/.npm-packages/lib/node_modules/homebridge-broadlink-rm/accessories/learnCode.js:41:17)
    at Characteristic.On.emit (events.js:198:13)
    at Characteristic.On.Characteristic.setValue (/Users/qwtel/.npm-packages/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Characteristic.js:321:10)
    at Bridge.<anonymous> (/Users/qwtel/.npm-packages/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:882:22)
    at Array.forEach (<anonymous>:null:null)
    at Bridge.Accessory._handleSetCharacteristics (/Users/qwtel/.npm-packages/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:822:8)
    at HAPServer.emit (events.js:198:13)
    at HAPServer._handleCharacteristics (/Users/qwtel/.npm-packages/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:974:10)
    at HAPServer.<anonymous> (/Users/qwtel/.npm-packages/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:209:39)
    at IncomingMessage.emit (events.js:198:13)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```